### PR TITLE
feat: Add basic Read function for githubipallowlist_ip_allow_list_entry

### DIFF
--- a/github/http_mock_test.go
+++ b/github/http_mock_test.go
@@ -3,6 +3,12 @@ package github
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	gitHubTimeFormat = "2006-01-02T15:04:05Z"
 )
 
 func serverReturning(body string) *httptest.Server {
@@ -17,4 +23,20 @@ func serverReturningAnEmptyResponseWith(statusCode int) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(statusCode)
 	}))
+}
+
+func truncateToGitHubPrecision(t time.Time) time.Time {
+	return t.UTC().Truncate(time.Second)
+}
+
+func serverReturningConsecutiveResponses(responseBodies ...string) (*httptest.Server, *atomic.Int64) {
+	var requestSent atomic.Int64
+	requestSent.Store(0)
+	gitHubGraphQLAPIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		currentRequest := requestSent.Load()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBodies[currentRequest]))
+		requestSent.Add(1)
+	}))
+	return gitHubGraphQLAPIMock, &requestSent
 }

--- a/github/ip_allow_list_test.go
+++ b/github/ip_allow_list_test.go
@@ -9,10 +9,6 @@ import (
 	"time"
 )
 
-const (
-	timeFormat = "2006-01-02T15:04:05Z"
-)
-
 const createEntryResponseTemplate = `
 {
     "data": {
@@ -64,6 +60,6 @@ func TestCreateIPAllowListEntryWithFailingServer(t *testing.T) {
 }
 
 func createEntryResponseWith(expectedEntry IPAllowListEntry) string {
-	res := fmt.Sprintf(createEntryResponseTemplate, expectedEntry.ID, expectedEntry.CreatedAt.Format(timeFormat), expectedEntry.UpdatedAt.Format(timeFormat), expectedEntry.AllowListValue, expectedEntry.IsActive, expectedEntry.Name)
+	res := fmt.Sprintf(createEntryResponseTemplate, expectedEntry.ID, expectedEntry.CreatedAt.Format(gitHubTimeFormat), expectedEntry.UpdatedAt.Format(gitHubTimeFormat), expectedEntry.AllowListValue, expectedEntry.IsActive, expectedEntry.Name)
 	return res
 }

--- a/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
+++ b/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
@@ -68,7 +68,9 @@ func resourceGitHubIPAllowListEntryRead(ctx context.Context, d *schema.ResourceD
 	id := d.Id()
 	entry := firstEntryByID(entries, id)
 	if entry == nil {
-		return diag.Errorf("githubipallowlist_ip_allow_list_entry not found id=%s", id)
+		tflog.Warn(ctx, "githubipallowlist_ip_allow_list_entry not found", map[string]interface{}{"id": id})
+		d.SetId("")
+		return nil
 	}
 	err = d.Set(isActiveKey, entry.IsActive)
 	if err != nil {
@@ -84,7 +86,7 @@ func resourceGitHubIPAllowListEntryRead(ctx context.Context, d *schema.ResourceD
 
 func firstEntryByID(entries []*github.IPAllowListEntry, id string) *github.IPAllowListEntry {
 	for _, e := range entries {
-		if e.ID == id {
+		if e != nil && e.ID == id {
 			return e
 		}
 	}

--- a/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
+++ b/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"github.com/form3tech-oss/terraform-provider-githubipallowlist/github"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -9,7 +10,9 @@ import (
 )
 
 const (
-	entryDescription = "Managed by Terraform"
+	entryDescription  = "Managed by Terraform"
+	isActiveKey       = "is_active"
+	allowListValueKey = "allow_list_value"
 )
 
 func resourceGitHubIPAllowListEntry() *schema.Resource {
@@ -22,12 +25,12 @@ func resourceGitHubIPAllowListEntry() *schema.Resource {
 		DeleteContext: resourceGitHubIPAllowListEntryDelete,
 
 		Schema: map[string]*schema.Schema{
-			"is_active": {
+			isActiveKey: {
 				Description: "Whether the entry is currently active.",
 				Type:        schema.TypeBool,
 				Required:    true,
 			},
-			"allow_list_value": {
+			allowListValueKey: {
 				Description: "A single IP address or range of IP addresses in CIDR notation.",
 				Type:        schema.TypeString,
 				Required:    true,
@@ -39,8 +42,8 @@ func resourceGitHubIPAllowListEntry() *schema.Resource {
 func resourceGitHubIPAllowListEntryCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*apiClient)
 
-	isActive := d.Get("is_active").(bool)
-	value := d.Get("allow_list_value").(string)
+	isActive := d.Get(isActiveKey).(bool)
+	value := d.Get(allowListValueKey).(string)
 
 	entry, err := client.github.CreateIPAllowListEntry(ctx, client.ownerID, entryDescription, value, isActive)
 	if err != nil {
@@ -55,10 +58,37 @@ func resourceGitHubIPAllowListEntryCreate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceGitHubIPAllowListEntryRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// use the meta value to retrieve your client from the provider configure method
-	// client := meta.(*apiClient)
+	client := meta.(*apiClient)
 
-	return diag.Errorf("not implemented")
+	entries, err := client.github.GetOrganizationIPAllowListEntries(ctx, client.organization)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := d.Id()
+	entry := firstEntryByID(entries, id)
+	if entry == nil {
+		return diag.Errorf("githubipallowlist_ip_allow_list_entry not found id=%s", id)
+	}
+	err = d.Set(isActiveKey, entry.IsActive)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set(allowListValueKey, entry.AllowListValue)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func firstEntryByID(entries []*github.IPAllowListEntry, id string) *github.IPAllowListEntry {
+	for _, e := range entries {
+		if e.ID == id {
+			return e
+		}
+	}
+	return nil
 }
 
 func resourceGitHubIPAllowListEntryUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {


### PR DESCRIPTION
This change adds a basic implementation of Read function for githubipallowlist_ip_allow_list_entry resource.

The implementation is intentionally simplified to focus on minimal functionality increments rather than robustness. Right now, the provider will read all entries (all pages) for every resource instance. Reducing usage of the GitHub API and other optimizations are planned for subsequent pull requests.

To validate changes run the `simple` example from `examples` directory:

1. Follow [Building The Provider section from README](https://github.com/form3tech-oss/terraform-provider-githubipallowlist/blob/5f6a0e2f6bafc5c041256b8fd4512eb8a0b7e936/README.md#building-the-provider)
2. Generate a Personal Access Token (classic) with an `admin:org` scope.
3. Run the following script filling missing variables:

  ```shell
  cd $PROJECT_ROOT/examples/simple
  export GITHUB_TOKEN=$GENERATED_TOKEN
  export GITHUB_ORGANIZATION=$YOUR_ORGANIZATION_NAME
  terraform plan
  terraform apply
  sed -i '' 's/1.2.3.4/1.2.3.5/' main.tf # macOS syntax
  terraform plan
  ```

4. Manually delete IP `1.2.3.4/32` allow list entry from your organization.


Example execution:

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/82932694/210576495-a2d103ba-3260-44ae-bfb0-abf599f5f5b5.png">


