### PR TITLE
feat: Add Delete function for githubipallowlist_ip_allow_list_entry resource

### DIFF
--- a/github/ip_allow_list.go
+++ b/github/ip_allow_list.go
@@ -31,6 +31,24 @@ mutation CreateIpAllowListEntry($ownerId: ID!, $name: String = "", $value: Strin
   }
 }`
 
+const deleteIPAllowListEntryMutation = `
+mutation DeleteIpAllowListEntry($entryId: ID!) {
+  deleteIpAllowListEntry(input: {ipAllowListEntryId: $entryId}) {
+    ipAllowListEntry {
+      id
+    }
+  }
+}
+`
+
+type DeleteUpAllowListEntryMutationResponse struct {
+	DeleteIpAllowListEntry struct {
+		IpAllowListEntry struct {
+			ID string `json:"id"`
+		} `json:"ipAllowListEntry"`
+	} `json:"deleteIpAllowListEntry"`
+}
+
 type CreateIPAllowListEntryMutationResponse struct {
 	CreateIPAllowListEntry struct {
 		IPAllowListEntry IPAllowListEntry `json:"ipAllowListEntry"`
@@ -58,4 +76,21 @@ func (c *Client) CreateIPAllowListEntry(ctx context.Context, ownerID string, nam
 	}
 
 	return &resData.CreateIPAllowListEntry.IPAllowListEntry, nil
+}
+
+// DeleteIPAllowListEntry uses deleteIpAllowListEntry GraphQL mutation to delete an IP allow list entry with a given entryID.
+// Returns entryID of the deleted entry.
+func (c *Client) DeleteIPAllowListEntry(ctx context.Context, entryID string) (string, error) {
+	reqData := GraphQLRequest{
+		Query: deleteIPAllowListEntryMutation,
+		Variables: map[string]any{
+			"entryId": entryID,
+		}}
+
+	resData, err := doRequest[DeleteUpAllowListEntryMutationResponse](ctx, c, reqData)
+	if err != nil {
+		return "", errors.Wrap(err, "DeleteIPAllowListEntry error")
+	}
+
+	return resData.DeleteIpAllowListEntry.IpAllowListEntry.ID, nil
 }

--- a/github/ip_allow_list_test.go
+++ b/github/ip_allow_list_test.go
@@ -81,14 +81,17 @@ func TestCreateIPAllowListEntry(t *testing.T) {
 
 func TestCreateIPAllowListEntryWithFailingServer(t *testing.T) {
 	// given
-	gitHubGraphQLAPIMock := serverReturningAnEmptyResponseWith(http.StatusInternalServerError)
+	expectedStatusCode := http.StatusInternalServerError
+	gitHubGraphQLAPIMock := serverReturningAnEmptyResponseWith(expectedStatusCode)
 	client := NewAuthenticatedGitHubClient(context.TODO(), "", WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL))
 
 	// when
 	createdEntry, err := client.CreateIPAllowListEntry(context.TODO(), "some owner", "some name", "some value", true)
 
 	// then
-	assert.Error(t, err)
+	var target ErrorWithStatusCode
+	assert.ErrorAs(t, err, &target)
+	assert.Equal(t, target.StatusCode, expectedStatusCode)
 	assert.Nil(t, createdEntry)
 }
 

--- a/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
+++ b/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
@@ -52,7 +52,7 @@ func resourceGitHubIPAllowListEntryCreate(ctx context.Context, d *schema.Resourc
 
 	d.SetId(entry.ID)
 
-	tflog.Trace(ctx, "created a resource githubipallowlist_ip_allow_list_entry")
+	tflog.Trace(ctx, "created a resource githubipallowlist_ip_allow_list_entry", map[string]interface{}{"id": entry.ID})
 
 	return nil
 }

--- a/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
+++ b/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
@@ -101,8 +101,13 @@ func resourceGitHubIPAllowListEntryUpdate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceGitHubIPAllowListEntryDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// use the meta value to retrieve your client from the provider configure method
-	// client := meta.(*apiClient)
+	client := meta.(*apiClient)
 
-	return diag.Errorf("not implemented")
+	deletedEntryID, err := client.github.DeleteIPAllowListEntry(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	tflog.Trace(ctx, "deleted a resource githubipallowlist_ip_allow_list_entry", map[string]interface{}{"id": deletedEntryID})
+
+	return nil
 }


### PR DESCRIPTION
This change adds the Delete function for githubipallowlist_ip_allow_list_entry resource.

To validate changes run the `simple` example from `examples` directory:

1. Follow [Building The Provider section from README](https://github.com/form3tech-oss/terraform-provider-githubipallowlist/blob/5f6a0e2f6bafc5c041256b8fd4512eb8a0b7e936/README.md#building-the-provider)
2. Generate a Personal Access Token (classic) with an `admin:org` scope.
3. Run the following script filling missing variables:

  ```shell
  cd $PROJECT_ROOT/examples/simple
  export GITHUB_TOKEN=$GENERATED_TOKEN
  export GITHUB_ORGANIZATION=$YOUR_ORGANIZATION_NAME
  terraform apply -auto-approve
  terraform destroy -auto-approve
  ```

Example execution:

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/82932694/211316147-0ebc5aed-56db-4f88-b5b1-3f49f1d4c5ea.png">

