### PR TITLE
feat: Add Update function for githubipallowlist_ip_allow_list_entry resource

### DIFF
--- a/github/ip_allow_list.go
+++ b/github/ip_allow_list.go
@@ -45,6 +45,28 @@ type CreateIPAllowListEntryMutationResponse struct {
 	} `json:"createIpAllowListEntry"`
 }
 
+const updateIPAllowListEntryMutation = `
+mutation UpdateIpAllowListEntry($entryId: ID!, $name: String!, $value: String!, $isActive: Boolean!) {
+  updateIpAllowListEntry(
+    input: {ipAllowListEntryId: $entryId, allowListValue: $value, isActive: $isActive, name: $name}
+  ) {
+      ipAllowListEntry {
+      allowListValue
+      createdAt
+      id
+      isActive
+      name
+      updatedAt
+    }
+  }
+}`
+
+type UpdateIPAllowListEntryMutationResponse struct {
+	UpdateIPAllowListEntry struct {
+		IPAllowListEntry IPAllowListEntry `json:"ipAllowListEntry"`
+	} `json:"updateIpAllowListEntry"`
+}
+
 // CreateIPAllowListEntry uses createIpAllowListEntry GraphQL mutation to create a new IP allow list entry for a given ownerID (organization or enterprise).
 // Returns the newly created entry.
 func (c *Client) CreateIPAllowListEntry(ctx context.Context, ownerID string, name string, value CIDR, isActive bool) (*IPAllowListEntry, error) {
@@ -66,4 +88,22 @@ func (c *Client) CreateIPAllowListEntry(ctx context.Context, ownerID string, nam
 	}
 
 	return &resData.CreateIPAllowListEntry.IPAllowListEntry, nil
+}
+
+func (c *Client) UpdateIPAllowListEntry(ctx context.Context, entryID string, params IPAllowListEntryParameters) (*IPAllowListEntry, error) {
+	reqData := GraphQLRequest{
+		Query: updateIPAllowListEntryMutation,
+		Variables: map[string]any{
+			"entryId":  entryID,
+			"name":     params.Name,
+			"value":    params.Value,
+			"isActive": params.IsActive,
+		}}
+
+	resData, err := doRequest[UpdateIPAllowListEntryMutationResponse](ctx, c, reqData)
+	if err != nil {
+		return nil, errors.Wrap(err, "UpdateIPAllowListEntry error")
+	}
+
+	return &resData.UpdateIPAllowListEntry.IPAllowListEntry, nil
 }

--- a/github/ip_allow_list.go
+++ b/github/ip_allow_list.go
@@ -6,11 +6,19 @@ import (
 	"time"
 )
 
+type CIDR string
+
+type IPAllowListEntryParameters struct {
+	Name     string
+	Value    CIDR
+	IsActive bool
+}
+
 type IPAllowListEntry struct {
 	ID             string    `json:"id"`
 	CreatedAt      time.Time `json:"createdAt"`
 	UpdatedAt      time.Time `json:"updatedAt"`
-	AllowListValue string    `json:"allowListValue"`
+	AllowListValue CIDR      `json:"allowListValue"`
 	IsActive       bool      `json:"isActive"`
 	Name           string    `json:"name"`
 }
@@ -39,7 +47,7 @@ type CreateIPAllowListEntryMutationResponse struct {
 
 // CreateIPAllowListEntry uses createIpAllowListEntry GraphQL mutation to create a new IP allow list entry for a given ownerID (organization or enterprise).
 // Returns the newly created entry.
-func (c *Client) CreateIPAllowListEntry(ctx context.Context, ownerID string, name string, value string, isActive bool) (*IPAllowListEntry, error) {
+func (c *Client) CreateIPAllowListEntry(ctx context.Context, ownerID string, name string, value CIDR, isActive bool) (*IPAllowListEntry, error) {
 	reqData := GraphQLRequest{
 		Query: createIPAllowListEntryMutation,
 		Variables: map[string]any{

--- a/github/ip_allow_list_test.go
+++ b/github/ip_allow_list_test.go
@@ -9,6 +9,12 @@ import (
 	"time"
 )
 
+var someIpAllowListEntryParameters = IPAllowListEntryParameters{
+	Name:     "some-name",
+	Value:    "some value",
+	IsActive: false,
+}
+
 const createEntryResponseTemplate = `
 {
     "data": {
@@ -23,6 +29,44 @@ const createEntryResponseTemplate = `
             }
         }
     }
+}`
+
+const updateEntryResponseTemplate = `
+{
+    "data": {
+        "updateIpAllowListEntry": {
+            "ipAllowListEntry": {
+                "id": "%s",
+                "allowListValue": "%s",
+                "isActive": %t,
+                "name": "%s",
+                "createdAt": "%s",
+                "updatedAt": "%s"
+            }
+        }
+    }
+}`
+
+const updateEntryResponseForMissingEntry = `
+{
+    "data": {
+        "updateIpAllowListEntry": null
+    },
+    "errors": [
+        {
+            "type": "NOT_FOUND",
+            "path": [
+                "updateIpAllowListEntry"
+            ],
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 3
+                }
+            ],
+            "message": "Could not resolve to a node with the global id of 'abc-123'"
+        }
+    ]
 }`
 
 func TestCreateIPAllowListEntry(t *testing.T) {
@@ -59,7 +103,68 @@ func TestCreateIPAllowListEntryWithFailingServer(t *testing.T) {
 	assert.Nil(t, createdEntry)
 }
 
+func TestUpdateIPAllowListEntry(t *testing.T) {
+	// given
+	expectedEntry := IPAllowListEntry{
+		ID:             "some-entry-id",
+		CreatedAt:      time.Now().UTC().Truncate(time.Second),
+		UpdatedAt:      time.Now().UTC().Truncate(time.Second),
+		AllowListValue: "1.2.3.4/32",
+		IsActive:       true,
+		Name:           "some name",
+	}
+	expectedParameters := IPAllowListEntryParameters{
+		Name:     expectedEntry.Name,
+		Value:    expectedEntry.AllowListValue,
+		IsActive: expectedEntry.IsActive,
+	}
+	gitHubGraphQLAPIMock := serverReturning(updateEntryResponseWith(expectedEntry))
+	client := NewAuthenticatedGitHubClient(context.TODO(), "", WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL))
+
+	// when
+	updatedEntry, err := client.UpdateIPAllowListEntry(context.TODO(), "some-entry-id", expectedParameters)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedEntry, *updatedEntry)
+}
+
+func TestUpdateIPAllowListEntryWithMissingEntry(t *testing.T) {
+	// given
+	gitHubGraphQLAPIMock := serverReturning(updateEntryResponseForMissingEntry)
+	client := NewAuthenticatedGitHubClient(context.TODO(), "", WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL))
+
+	// when
+	deletedEntryID, err := client.UpdateIPAllowListEntry(context.TODO(), "some-entry-id", someIpAllowListEntryParameters)
+
+	// then
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Could not resolve to a node with the global id of 'abc-123'")
+	assert.Empty(t, deletedEntryID)
+}
+
+func TestUpdateIPAllowListEntryWithFailingServer(t *testing.T) {
+	// given
+	expectedStatusCode := http.StatusInternalServerError
+	gitHubGraphQLAPIMock := serverReturningAnEmptyResponseWith(expectedStatusCode)
+	client := NewAuthenticatedGitHubClient(context.TODO(), "", WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL))
+
+	// when
+	deletedEntryID, err := client.UpdateIPAllowListEntry(context.TODO(), "some-entry-id", someIpAllowListEntryParameters)
+
+	// then
+	var target ErrorWithStatusCode
+	assert.ErrorAs(t, err, &target)
+	assert.Equal(t, target.StatusCode, expectedStatusCode)
+	assert.Empty(t, deletedEntryID)
+}
+
 func createEntryResponseWith(expectedEntry IPAllowListEntry) string {
 	res := fmt.Sprintf(createEntryResponseTemplate, expectedEntry.ID, expectedEntry.CreatedAt.Format(gitHubTimeFormat), expectedEntry.UpdatedAt.Format(gitHubTimeFormat), expectedEntry.AllowListValue, expectedEntry.IsActive, expectedEntry.Name)
+	return res
+}
+
+func updateEntryResponseWith(expectedEntry IPAllowListEntry) string {
+	res := fmt.Sprintf(updateEntryResponseTemplate, expectedEntry.ID, expectedEntry.AllowListValue, expectedEntry.IsActive, expectedEntry.Name, expectedEntry.CreatedAt.Format(gitHubTimeFormat), expectedEntry.UpdatedAt.Format(gitHubTimeFormat))
 	return res
 }

--- a/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
+++ b/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
@@ -45,7 +45,7 @@ func resourceGitHubIPAllowListEntryCreate(ctx context.Context, d *schema.Resourc
 	isActive := d.Get(isActiveKey).(bool)
 	value := d.Get(allowListValueKey).(string)
 
-	entry, err := client.github.CreateIPAllowListEntry(ctx, client.ownerID, entryDescription, value, isActive)
+	entry, err := client.github.CreateIPAllowListEntry(ctx, client.ownerID, entryDescription, github.CIDR(value), isActive)
 	if err != nil {
 		diag.FromErr(err)
 	}

--- a/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
+++ b/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
@@ -94,10 +94,35 @@ func firstEntryByID(entries []*github.IPAllowListEntry, id string) *github.IPAll
 }
 
 func resourceGitHubIPAllowListEntryUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// use the meta value to retrieve your client from the provider configure method
-	// client := meta.(*apiClient)
+	client := meta.(*apiClient)
 
-	return diag.Errorf("not implemented")
+	id := d.Id()
+	isActive := d.Get(isActiveKey).(bool)
+	value := d.Get(allowListValueKey).(string)
+
+	entry, err := client.github.UpdateIPAllowListEntry(ctx, id,
+		github.IPAllowListEntryParameters{
+			Name:     entryDescription,
+			Value:    github.CIDR(value),
+			IsActive: isActive,
+		})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set(isActiveKey, entry.IsActive)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set(allowListValueKey, entry.AllowListValue)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(entry.ID)
+
+	tflog.Trace(ctx, "updated a resource githubipallowlist_ip_allow_list_entry", map[string]interface{}{"id": entry.ID})
+
+	return nil
 }
 
 func resourceGitHubIPAllowListEntryDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {


### PR DESCRIPTION
This change adds the Update function for githubipallowlist_ip_allow_list_entry resource.

To validate changes run the `simple` example from `examples` directory:

1. Follow [Building The Provider section from README](https://github.com/form3tech-oss/terraform-provider-githubipallowlist/blob/5f6a0e2f6bafc5c041256b8fd4512eb8a0b7e936/README.md#building-the-provider)
2. Generate a Personal Access Token (classic) with an `admin:org` scope.
3. Run the following script filling missing variables:

  ```shell
  cd $PROJECT_ROOT/examples/simple
  export GITHUB_TOKEN=$GENERATED_TOKEN
  export GITHUB_ORGANIZATION=$YOUR_ORGANIZATION_NAME
  terraform apply -auto-approve
  sed -i '' 's/1.2.3.4/1.2.3.5/' main.tf
  terraform apply -auto-approve
  terraform destroy -auto-approve
  ```

Example output:

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/82932694/211347673-51f4d530-d5d0-4474-8945-07aa1e57f3f9.png">
