### PR TITLE
feat: Add optional read cache

### DIFF
--- a/github/client_test.go
+++ b/github/client_test.go
@@ -145,7 +145,7 @@ func TestClientCanExecuteRequestsConcurrently(t *testing.T) {
 		t.Run(fmt.Sprintf("Concurrency:%d", test.concurrentRequests), func(t *testing.T) {
 			// given
 			gitHubGraphQLAPIMock, receivedRequests := serverWaitingWithWritingAResponseUntilAllRequestsAreReceived(test.concurrentRequests)
-			client := NewAuthenticatedGitHubClient(context.TODO(), "", WithConcurrency(int64(test.concurrentRequests)), WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL))
+			client := NewAuthenticatedGitHubClient(context.TODO(), "", WithConcurrency(int64(test.concurrentRequests)), WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL), WithoutEntriesCaching())
 
 			// when
 			for i := 0; i < test.concurrentRequests; i++ {
@@ -179,7 +179,7 @@ func TestClientCanNotExceedMaxConcurrentRequests(t *testing.T) {
 		t.Run(fmt.Sprintf("Concurrency:%d", test.concurrentRequests), func(t *testing.T) {
 			// given
 			gitHubGraphQLAPIMock, receivedRequests := serverWaitingWithWritingAResponseUntilAllRequestsAreReceived(test.concurrentRequests + 1)
-			client := NewAuthenticatedGitHubClient(context.TODO(), "", WithConcurrency(int64(test.concurrentRequests)), WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL))
+			client := NewAuthenticatedGitHubClient(context.TODO(), "", WithConcurrency(int64(test.concurrentRequests)), WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL), WithoutEntriesCaching())
 
 			// when
 			for i := 0; i < test.concurrentRequests; i++ {

--- a/github/ip_allow_list_test.go
+++ b/github/ip_allow_list_test.go
@@ -109,8 +109,8 @@ func TestCreateIPAllowListEntry(t *testing.T) {
 		AllowListValue: "1.2.3.4/32",
 		IsActive:       true,
 		Name:           "some name",
-		CreatedAt:      time.Now().UTC().Truncate(time.Second),
-		UpdatedAt:      time.Now().UTC().Truncate(time.Second),
+		CreatedAt:      truncateToGitHubPrecision(time.Now()),
+		UpdatedAt:      truncateToGitHubPrecision(time.Now()),
 	}
 	gitHubGraphQLAPIMock := serverReturning(createEntryResponseWith(expectedEntry))
 	client := NewAuthenticatedGitHubClient(context.TODO(), "", WithGraphQLAPIURL(gitHubGraphQLAPIMock.URL))
@@ -187,8 +187,8 @@ func TestUpdateIPAllowListEntry(t *testing.T) {
 	// given
 	expectedEntry := IPAllowListEntry{
 		ID:             "some-entry-id",
-		CreatedAt:      time.Now().UTC().Truncate(time.Second),
-		UpdatedAt:      time.Now().UTC().Truncate(time.Second),
+		CreatedAt:      truncateToGitHubPrecision(time.Now()),
+		UpdatedAt:      truncateToGitHubPrecision(time.Now()),
 		AllowListValue: "1.2.3.4/32",
 		IsActive:       true,
 		Name:           "some name",

--- a/github/organization_ip_allow_list.go
+++ b/github/organization_ip_allow_list.go
@@ -52,6 +52,37 @@ type GetOrganizationIPAllowListQueryResponse struct {
 // Method fetches all entries which might be a subject to rate limiting for allow lists with a big number of entries.
 // Returns a slice of pointers to an entry as the API returns nil for entries managed on an enterprise level.
 func (c *Client) GetOrganizationIPAllowListEntries(ctx context.Context, organizationName string) ([]*IPAllowListEntry, error) {
+	var entries []*IPAllowListEntry
+	var err error
+	if c.cacheEntries {
+		entries, err = c.getOrganizationIPAllowListEntriesWithCache(ctx, organizationName)
+	} else {
+		entries, err = c.getOrganizationIPAllowListEntries(ctx, organizationName)
+	}
+
+	return entries, err
+}
+
+func (c *Client) getOrganizationIPAllowListEntriesWithCache(ctx context.Context, organizationName string) ([]*IPAllowListEntry, error) {
+	c.organizationEntriesCacheMutex.Lock()
+	defer c.organizationEntriesCacheMutex.Unlock()
+
+	var entries []*IPAllowListEntry
+	var ok bool
+	entries, ok = c.organizationEntriesCache[organizationName]
+	if !ok {
+		var err error
+		entries, err = c.getOrganizationIPAllowListEntries(ctx, organizationName)
+		if err != nil {
+			return entries, errors.Wrap(err, "getOrganizationIPAllowListEntriesWithCache error")
+		}
+
+		c.organizationEntriesCache[organizationName] = entries
+	}
+	return entries, nil
+}
+
+func (c *Client) getOrganizationIPAllowListEntries(ctx context.Context, organizationName string) ([]*IPAllowListEntry, error) {
 	reqData := GraphQLRequest{Query: getOrganizationIPAllowListEntriesQuery, Variables: map[string]any{"org": organizationName}}
 	entries, err := paginate[GetOrganizationIPAllowListQueryResponse, IPAllowListEntry](ctx, c, reqData,
 		func(t *GetOrganizationIPAllowListQueryResponse) []*IPAllowListEntry {
@@ -61,9 +92,8 @@ func (c *Client) GetOrganizationIPAllowListEntries(ctx context.Context, organiza
 		})
 
 	if err != nil {
-		return []*IPAllowListEntry{}, errors.Wrap(err, "GetOrganizationIPAllowListEntries error")
+		return []*IPAllowListEntry{}, errors.Wrap(err, "getOrganizationIPAllowListEntries error")
 	}
-
 	return entries, nil
 }
 


### PR DESCRIPTION
`GetOrganizationIPAllowListEntries` executes multiple calls to GitHub GraphQL API to read all IP allow-list entries, i.e. it reads all pages. Since `GetOrganizationIPAllowListEntries` is called in Read function of 
`githubipallowlist_ip_allow_list_entry` resource, it's called once for an every resource instance. As a result, the provider fetches the same data over and over again.

To reduce these redundant calls we're introducing an optional simple read cache for `GetOrganizationIPAllowListEntries` function that's enabled by default.
The implementation uses a simple synchronized map without any eviction policies. This results in a single batch of calls to GitHub GraphQL API for all `GetOrganizationIPAllowListEntries` calls in the whole lifetime of the 
client. This behaviour should be enough for purposes of a Terraform provider, as we only refresh the whole state once. All updates return updated values, therefore there's no need for reconciling reads as well.
The change is transparent for the provider's code. Although current implementation is not optimal, we're doing a whole entries slice scan for every entry read, improvements provided by caching are substantial while keeping the 
client's API as close to GitHub GraphQL schema, the implementation simple and testable in unit and integration tests. Further improvements and optimizations are left for future.

