### PR TITLE
fix: Return diagnostic error when failed to create entry

### DIFF
--- a/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
+++ b/internal/provider/resource_githubipallowlist_ip_allow_list_entry.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/form3tech-oss/terraform-provider-githubipallowlist/github"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -47,7 +48,7 @@ func resourceGitHubIPAllowListEntryCreate(ctx context.Context, d *schema.Resourc
 
 	entry, err := client.github.CreateIPAllowListEntry(ctx, client.ownerID, entryDescription, github.CIDR(value), isActive)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(entry.ID)


### PR DESCRIPTION
Error was not returned from create handler, which in turn produced badly formatted error on failed create.